### PR TITLE
EVG-13297: carry over scheduling-aware calculations to DAG structure

### DIFF
--- a/get_task_data.sh
+++ b/get_task_data.sh
@@ -32,7 +32,7 @@ DB_HOST=evergreendb-1.10gen-mci.4085.mongodbdns.com
 JS_FILE=get_tasks.js
 
 SCP_FILE='/tmp/result.json'
-OUT_FILE=foobar.json
+OUT_FILE=rhel62-small.json
 
 run_aggregation "$DB_HOST" "$JS_FILE" "$SCP_FILE"
 clean_results $(basename "$SCP_FILE") "$OUT_FILE"

--- a/get_tasks.js
+++ b/get_tasks.js
@@ -4,9 +4,9 @@ function problemChild(){
 return db.tasks.aggregate([
 {$match: {finish_time: {$gt: ISODate("2020-10-12T00:00:00.000Z")}}},
 {$match: {finish_time: {$lt: ISODate("2020-10-12T24:00:00.000Z")}}},
-{$match: {distro: 'rhel62-small' }},
 {$project: {create_time:1, dispatch_time:1, scheduled_time:1, start_time:1, finish_time:1, priority:1, distro:1, depends_on:1, version:1, display_only:1, generated_by:1}},
 ])};
 //toArray makes this valid json for later loading into python
 var x = problemChild().toArray();
 printjson(x)
+//{$match: {distro: 'rhel62-small' }},

--- a/get_tasks.js
+++ b/get_tasks.js
@@ -4,7 +4,7 @@ function problemChild(){
 return db.tasks.aggregate([
 {$match: {finish_time: {$gt: ISODate("2020-10-12T00:00:00.000Z")}}},
 {$match: {finish_time: {$lt: ISODate("2020-10-12T24:00:00.000Z")}}},
-{$match: {dist: 'foobar' }},
+{$match: {distro: 'rhel62-small' }},
 {$project: {create_time:1, dispatch_time:1, scheduled_time:1, start_time:1, finish_time:1, priority:1, distro:1, depends_on:1, version:1, display_only:1, generated_by:1}},
 ])};
 //toArray makes this valid json for later loading into python

--- a/get_tasks.js
+++ b/get_tasks.js
@@ -2,9 +2,9 @@ rs.slaveOk();
 db = db.getSiblingDB('mci');
 function problemChild(){
 return db.tasks.aggregate([
-{$match: {finish_time: {$gt: ISODate("2020-10-12T12:00:00.000Z")}}},
-{$match: {finish_time: {$lt: ISODate("2020-10-17T08:00:00.000Z")}}},
-{$match: {version: 'foobar' }},
+{$match: {finish_time: {$gt: ISODate("2020-10-12T00:00:00.000Z")}}},
+{$match: {finish_time: {$lt: ISODate("2020-10-12T24:00:00.000Z")}}},
+{$match: {dist: 'foobar' }},
 {$project: {create_time:1, dispatch_time:1, scheduled_time:1, start_time:1, finish_time:1, priority:1, distro:1, depends_on:1, version:1, display_only:1, generated_by:1}},
 ])};
 //toArray makes this valid json for later loading into python

--- a/metrics.py
+++ b/metrics.py
@@ -375,6 +375,8 @@ class DepGraph:
         # make implicit dependency of generated on generator explicit
         generator_tasks = {}
         for task_id in tasks:
+            if 'begin_wait' not in tasks[task_id]:
+                raise ValueError('begin_wait missing from: {}'.format(task_id))
             if 'generated_by' in tasks[task_id]:
                 generated_by = tasks[task_id]['generated_by']
                 if generated_by in generator_tasks:
@@ -432,7 +434,7 @@ class DepGraph:
         source_id = 'dummy_source'
         source_vertex = {'_id': source_id, 'depends_on':[{'_id':x} for x in task_ids_with_zero_indegree]}
         source_vertex['start_time'] = earliest_scheduled
-        source_vertex['scheduled_time'] = earliest_scheduled 
+        source_vertex['begin_wait'] = earliest_scheduled 
         source_vertex['finish_time'] = earliest_scheduled + datetime.timedelta(seconds=1)
         source_vertex_id = len(tasks)
         tasks[source_id] = source_vertex
@@ -440,7 +442,7 @@ class DepGraph:
         target_id = 'dummy_target'
         target_vertex = {'_id': target_id, 'depends_on':[]}
         target_vertex['start_time'] = latest_finish
-        target_vertex['scheduled_time'] = latest_finish
+        target_vertex['begin_wait'] = latest_finish
         target_vertex['finish_time'] = latest_finish + datetime.timedelta(seconds=1)
         target_vertex_id = len(tasks)
         tasks[target_id] = target_vertex
@@ -468,7 +470,7 @@ class DepGraph:
 
         def calculate_real_maxcost_path_weight(some_task):
             ''' helper to pass to graph constructor'''
-            timedelta_weight = some_task['finish_time'] - some_task['scheduled_time']
+            timedelta_weight = some_task['finish_time'] - some_task['begin_wait']
             seconds =  timedelta_weight.total_seconds()
             # invert to allow calculation of maxcost path by mincost-path algo
             return -1 * seconds

--- a/metrics.py
+++ b/metrics.py
@@ -15,7 +15,7 @@ import numpy as np
 import ETA
 
 logging.basicConfig(level=logging.INFO)
-IN_JSON = 'foobar.json'
+IN_JSON = 'rhel62-small.json'
 
 class DepWaitTaskTimes(ETA.TaskTimes):
     '''
@@ -217,7 +217,7 @@ class DepWaitTaskTimes(ETA.TaskTimes):
                 continue
 
             # set according to particular question you want to answer
-            if len(version_tasks) < 10:
+            if len(version_tasks) < 100:
                 continue
             try:
                 slowdown, _ = DepGraph.display_version_slowdown(version_tasks)
@@ -384,6 +384,8 @@ class DepGraph:
 
         for task_id in generator_tasks:
             dummy_id = task_id + '_dummygen'
+            if task_id not in tasks:
+                raise ValueError('incomplete task list. Dependency does not appear in task list: {}'.format(task_id))
             dummy_task = tasks[task_id].copy()
             dummy_task['finish_time'] = dummy_task['start_time']
             dummy_task['_id'] = dummy_id
@@ -430,6 +432,7 @@ class DepGraph:
         source_id = 'dummy_source'
         source_vertex = {'_id': source_id, 'depends_on':[{'_id':x} for x in task_ids_with_zero_indegree]}
         source_vertex['start_time'] = earliest_scheduled
+        source_vertex['scheduled_time'] = earliest_scheduled 
         source_vertex['finish_time'] = earliest_scheduled + datetime.timedelta(seconds=1)
         source_vertex_id = len(tasks)
         tasks[source_id] = source_vertex
@@ -437,6 +440,7 @@ class DepGraph:
         target_id = 'dummy_target'
         target_vertex = {'_id': target_id, 'depends_on':[]}
         target_vertex['start_time'] = latest_finish
+        target_vertex['scheduled_time'] = latest_finish
         target_vertex['finish_time'] = latest_finish + datetime.timedelta(seconds=1)
         target_vertex_id = len(tasks)
         tasks[target_id] = target_vertex
@@ -478,12 +482,12 @@ class DepGraph:
 
         slowdown = real_latency_seconds/idealized_latency_seconds
         print('{} seconds or {} hours (actual)'.format(
-            real_version_latency_seconds, real_version_latency_seconds/60**2))
+            real_latency_seconds, real_latency_seconds/60**2))
 
         print('{} seconds or {} hours (idealized)'.format(
             idealized_latency_seconds, idealized_latency_seconds/60**2))
 
-        print('{} is slowdown'.format(real_version_latency_seconds/idealized_latency_seconds))
+        print('{} is slowdown'.format(real_latency_seconds/idealized_latency_seconds))
 
         return slowdown, depgraph
 

--- a/plots.py
+++ b/plots.py
@@ -11,8 +11,8 @@ import ETA.Chunks as chunks
 import metrics
 
 logging.basicConfig(level=logging.INFO)
-OUT_HTML = './foobar.html'
-IN_JSON = './foobar.json'
+OUT_HTML = './rhel62-small.html'
+IN_JSON = './rhel62-small.json'
 
 ##
 # gantt
@@ -148,11 +148,11 @@ def main():
     df = task_data.dataframe(generator)
     fig = generate_twocolor_timeline(df)
     #fig = generate_hist_corrected_wait_time(task_data)
-    fig.update_layout(title = 'foobar')
+    fig.update_layout(title = 'rhel62-small')
     fig.show()
     # cdn options reduce the size of the file by a couple of MB.
     fig.write_html(OUT_HTML,include_plotlyjs='cdn',include_mathjax='cdn')
-    fig.write_image('foobar.webp')
+    fig.write_image('rhel62-small.webp')
     print('figure saved at {}'.format(OUT_HTML))
 
 

--- a/plots.py
+++ b/plots.py
@@ -11,8 +11,8 @@ import ETA.Chunks as chunks
 import metrics
 
 logging.basicConfig(level=logging.INFO)
-OUT_HTML = './rhel62-small.html'
-IN_JSON = './rhel62-small.json'
+OUT_HTML = './foobar.html'
+IN_JSON = './foobar.json'
 
 ##
 # gantt
@@ -139,20 +139,19 @@ def main():
     task_data = metrics.DepWaitTaskTimes(IN_JSON,time_fields)
 
     # have to do this here to avoid polluting the unblock calculations
-    for task in task_data.get_tasks({'begin_wait':[],'start_time':[],'finish_time':[]}):
+    for task in task_data.get_tasks({'begin_wait':[],'start_time':[],'finish_time':[],'version':'foobar'}):
         # add eleven seconds to avoid plotly wierdness
         task['start_time'] += datetime.timedelta(0,11)
         task['finish_time'] += datetime.timedelta(0,22)
 
-    generator = task_data.get_tasks({'begin_wait':[],'start_time':[],'finish_time':[]})
+    generator = task_data.get_tasks({'begin_wait':[],'start_time':[],'finish_time':[],'version':'foobar'})
     df = task_data.dataframe(generator)
     fig = generate_twocolor_timeline(df)
     #fig = generate_hist_corrected_wait_time(task_data)
-    fig.update_layout(title = 'rhel62-small')
+    fig.update_layout(title = 'foobar')
     fig.show()
     # cdn options reduce the size of the file by a couple of MB.
     fig.write_html(OUT_HTML,include_plotlyjs='cdn',include_mathjax='cdn')
-    fig.write_image('rhel62-small.webp')
     print('figure saved at {}'.format(OUT_HTML))
 
 


### PR DESCRIPTION
I've tested this out on a limited dataset and it seems to perform wonderfully. It does not penalize versions for manually-scheduled tests; the versions that have high scores on this test contain exceptionally bad performance, all the low-scorers have good performance (that I checked), and no version out of about 100 calculated was below 100.